### PR TITLE
Factor common properties

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,1 +1,2 @@
 pub mod types;
+pub mod properties;

--- a/src/sdo/grouping.rs
+++ b/src/sdo/grouping.rs
@@ -1,28 +1,19 @@
 use crate::common::types::*;
+use crate::common::properties::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Grouping {
-    // Required Common Properties
-    spec_version: String,
-    id: Identifier,
-    created: Timestamp,
-    modified: Timestamp,
-
-    // Optional Common Properties
-    created_by_ref: Option<Identifier>,
-    revoked: Option<Boolean>,
-    labels: Option<List<String>>,
-    confidence: Integer,
-    lang: String,
-    external_references: List<ExternalReference>,
-    object_marking_refs: List<Identifier>,
-    granular_markings: List<GranularMarking>,
-    extensions: Dictionary,
-
-    // Grouping Specific Properties
+    #[serde(flatten)]
+    common: CommonProperties,
     name: Option<String>,
     description: Option<String>,
     context: OpenVocab,
     object_refs: List<Identifier>,
+}
+
+impl AsRef<CommonProperties> for Grouping {
+    fn as_ref(&self) -> &CommonProperties {
+        &self.common
+    }
 }


### PR DESCRIPTION
This PR uses `serde(flatten)` to inline the keys from a parent struct.
