### PR TITLE
Add guaranteed input validation for the Grouping type

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,37 @@
 pub mod common;
 pub mod sdo;
 
+fn test_grouping() {
+    // Invalid grouping: Contains 'defanged' key.
+    let grouping_defanged = r#"{
+      "type": "grouping",
+      "spec_version": "2.1",
+      "id": "grouping--84e4d88f-44ea-4bcd-bbf3-b2c1c320bcb3",
+      "defanged": true,
+      "created_by_ref": "identity--a463ffb3-1bd9-4d94-b02d-74e4f1658283",
+      "created": "2015-12-21T19:59:11.000Z",
+      "modified": "2015-12-21T19:59:11.000Z",
+      "name": "The Black Vine Cyberespionage Group",
+      "description": "A simple collection of Black Vine Cyberespionage Group attributed intel",
+      "context": "suspicious-activity",
+      "object_refs": [
+        "indicator--26ffb872-1dd9-446e-b6f5-d58527e5b5d2",
+        "campaign--83422c77-904c-4dc1-aff5-5c38f3a2c55c",
+        "relationship--f82356ae-fe6c-437c-9c24-6b64314ae68a",
+        "file--0203b5c8-f8b6-4ddb-9ad0-527d727f968b"
+      ]
+    }"#;
+
+    println!(
+        "{:?}",
+        serde_json::from_str::<sdo::STIXDomainObject>(grouping_defanged)
+    );
+}
+
 pub fn main() {
     let attack_pattern_json = "{\n\t\"type\": \"attack-pattern\",\n\t\"external_references\": null,\n\t\"name\": \"Some Attack Pattern\",\n\t\"description\": null,\n\t\"aliases\": null,\n\t\"kill_chain_phase\": null\n}";
     let campaign_json = "{ \"type\": \"campaign\", \"spec_version\": \"2.1\", \"id\": \"campaign--8e2e2d2b-17d4-4cbf-938f-98ee46b3cd3f\", \"created_by_ref\": \"identity--f431f809-377b-45e0-aa1c-6a4751cae5ff\", \"created\": \"2016-04-06T20:03:00.000Z\", \"modified\": \"2016-04-06T20:03:00.000Z\", \"name\": \"Green Group Attacks Against Finance\", \"description\": \"Campaign by Green Group against a series of targets in the financial services sector.\" }";
-    let grouping_json = r#"{
-  "type": "grouping",
-  "spec_version": "2.1",
-  "id": "grouping--84e4d88f-44ea-4bcd-bbf3-b2c1c320bcb3",
-  "created_by_ref": "identity--a463ffb3-1bd9-4d94-b02d-74e4f1658283",
-  "created": "2015-12-21T19:59:11.000Z",
-  "modified": "2015-12-21T19:59:11.000Z",
-  "name": "The Black Vine Cyberespionage Group",
-  "description": "A simple collection of Black Vine Cyberespionage Group attributed intel",
-  "context": "suspicious-activity",
-  "object_refs": [
-    "indicator--26ffb872-1dd9-446e-b6f5-d58527e5b5d2",
-    "campaign--83422c77-904c-4dc1-aff5-5c38f3a2c55c",
-    "relationship--f82356ae-fe6c-437c-9c24-6b64314ae68a",
-    "file--0203b5c8-f8b6-4ddb-9ad0-527d727f968b"
-  ]
-}"#;
+
     println!(
         "{:?}",
         serde_json::from_str::<sdo::STIXDomainObject>(attack_pattern_json)
@@ -29,9 +40,6 @@ pub fn main() {
         "{:?}",
         serde_json::from_str::<sdo::STIXDomainObject>(campaign_json)
     );
-    println!(
-        "{:?}",
-        serde_json::from_str::<sdo::STIXDomainObject>(grouping_json)
-    );
-}
 
+    test_grouping();
+}

--- a/src/sdo/course_of_action.rs
+++ b/src/sdo/course_of_action.rs
@@ -2,5 +2,4 @@ use crate::common::types::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct CourseOfAction {
-}
+pub struct CourseOfAction {}

--- a/src/sdo/grouping.rs
+++ b/src/sdo/grouping.rs
@@ -1,7 +1,40 @@
 use crate::common::types::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GroupingUnvalidated {
+    // Required Common Properties
+    spec_version: String,
+    id: Identifier,
+    created: Timestamp,
+    modified: Timestamp,
+
+    // Optional Common Properties
+    created_by_ref: Option<Identifier>,
+    revoked: Option<Boolean>,
+    labels: Option<List<String>>,
+    confidence: Option<Integer>,
+    lang: Option<String>,
+    external_references: Option<List<ExternalReference>>,
+    object_marking_refs: Option<List<Identifier>>,
+    granular_markings: Option<List<GranularMarking>>,
+    defanged: Option<Boolean>,
+    extensions: Option<Dictionary>,
+
+    // Grouping Specific Properties
+    name: Option<String>,
+    description: Option<String>,
+    context: OpenVocab,
+    object_refs: List<Identifier>,
+}
+
+// The 'grouping-context-ov' vocabulary.
+const GROUPING_CONTEXT_VOCABULARY: &'static [&'static str] =
+    &["suspicious-activity", "malware-analysis", "unspecified"];
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(try_from = "GroupingUnvalidated")]
 pub struct Grouping {
     // Required Common Properties
     spec_version: String,
@@ -13,16 +46,86 @@ pub struct Grouping {
     created_by_ref: Option<Identifier>,
     revoked: Option<Boolean>,
     labels: Option<List<String>>,
-    confidence: Integer,
-    lang: String,
-    external_references: List<ExternalReference>,
-    object_marking_refs: List<Identifier>,
-    granular_markings: List<GranularMarking>,
-    extensions: Dictionary,
+    confidence: Option<Integer>,
+    lang: Option<String>,
+    external_references: Option<List<ExternalReference>>,
+    object_marking_refs: Option<List<Identifier>>,
+    granular_markings: Option<List<GranularMarking>>,
+    defanged: Option<Boolean>,
+    extensions: Option<Dictionary>,
 
     // Grouping Specific Properties
     name: Option<String>,
     description: Option<String>,
     context: OpenVocab,
     object_refs: List<Identifier>,
+}
+
+pub struct Stix2ValidationError {
+    msg: String,
+}
+
+// The error type has to implement Display
+impl std::fmt::Display for Stix2ValidationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        return write!(formatter, "Invalid STIX2 object: {}", self.msg);
+    }
+}
+
+impl std::convert::TryFrom<GroupingUnvalidated> for Grouping {
+    type Error = Stix2ValidationError;
+    fn try_from(grouping: GroupingUnvalidated) -> Result<Self, Self::Error> {
+        let GroupingUnvalidated {
+            spec_version,
+            id,
+            created,
+            modified,
+            created_by_ref,
+            revoked,
+            labels,
+            confidence,
+            lang,
+            external_references,
+            object_marking_refs,
+            granular_markings,
+            defanged,
+            extensions,
+            name,
+            description,
+            context,
+            object_refs,
+        } = grouping;
+
+        if !defanged.is_none() {
+            return Err(Stix2ValidationError {
+                msg: "Common property 'defanged' is not applicable to 'Grouping' object"
+                    .to_string(),
+            });
+        }
+
+        // if !GROUPING_CONTEXT_VOCABULARY.iter().find(|&&x| x == &context) {
+        //     return Err(Stix2ValidationError {msg: "Invalid context value"});
+        // }
+
+        Ok(Grouping {
+            spec_version,
+            id,
+            created,
+            modified,
+            created_by_ref,
+            revoked,
+            labels,
+            confidence,
+            lang,
+            external_references,
+            object_marking_refs,
+            granular_markings,
+            defanged,
+            extensions,
+            name,
+            description,
+            context,
+            object_refs,
+        })
+    }
 }


### PR DESCRIPTION
This is a PoC for input validation. This specific example ensures that a 'Grouping' will not have the 'defanged' value set.

The basic idea is to to create a private "shadow struct" for the raw serialization/deserialization and then to use serde's `try_from` to add a post-parse validation step to create the real struct.